### PR TITLE
[38] Load the latest set after getting response

### DIFF
--- a/src/main/Main.js
+++ b/src/main/Main.js
@@ -21,14 +21,18 @@ class Main extends Component {
   }
 
   componentDidMount() {
-    this.getSets();
     this.storeCards(dummyData);
+    this.getSets();
   }
 
-  getSets = () => {
+  // TODO: refactor to be a set-up function
+  getSets = async () => {
     fetch('https://api.scryfall.com/sets')
       .then(response => response.json())
-      .then(data => this.setSets(data))
+      .then(async (data) => {
+        await this.setSets(data);
+        this.handleSetChange(this.state.sets[0].code);
+      })
       .catch(error => console.log(error));
   }
 
@@ -102,7 +106,7 @@ class Main extends Component {
   }
 
   handleSetChange = (val) => {
-    let url = 'https://api.scryfall.com/cards/search?q=%28o%3Aflash+or+t%3Ainstant%29+s%3A';
+    let url = 'https://api.scryfall.com/cards/search?q=is%3Abooster+%28o%3Aflash+or+t%3Ainstant%29+s%3A';
     url += val;
     this.loadSet(url);
   }


### PR DESCRIPTION
The previous behaviour was not great - you couldn't select the latest set
with one click of the select element as it was already selected. The dummy
data would also still be showing despite the select element showing a
different option. Loading the latest set should improve the experience.

Closes #38 